### PR TITLE
Fixes Digest::Digest deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,18 +4,18 @@ PATH
     url_store (0.3.4)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
-    rake (0.8.7)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    diff-lcs (1.2.5)
+    rake (10.1.1)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.4)
 
 PLATFORMS
   ruby

--- a/lib/url_store/compact_encoder.rb
+++ b/lib/url_store/compact_encoder.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'zlib'
+require 'yaml'
 
 class UrlStore
   class CompactEncoder
@@ -30,7 +31,7 @@ class UrlStore
     def serialize(data)
       case @serializer.to_sym
       when :yaml then data.to_yaml
-      when :marshal then Marshal.dump(data)  
+      when :marshal then Marshal.dump(data)
       end
     end
 
@@ -56,7 +57,7 @@ class UrlStore
     # stolen from ActiveSupport
     def digest(data)
       require 'openssl' unless defined?(OpenSSL)
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new(@hasher.to_s), @secret, data)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(@hasher.to_s), @secret, data)
     end
   end
 end


### PR DESCRIPTION
This fixes a deprecation warning that we're seeing in Ruby 2.1.

`Digest::Digest is deprecated; use Digest`
