### PR TITLE
Don't use "|", because Calendars on OSX does not allow it.

### DIFF
--- a/lib/url_store.rb
+++ b/lib/url_store.rb
@@ -7,8 +7,12 @@ class UrlStore
 
   # (convert to base64url <-> RFC4648) and '|'
   # which is not url-safe if you ask ERB/CGI, but browsers accept it
-  IN = '+/='
-  OUT = '-_|'
+  IN_0_3_5 = '+/='
+  OUT_0_3_5 = '-_|'
+
+  # Calendars on OSX does not like pipes. So we don't include them anymore.
+  IN = '+/'
+  OUT = '-_'
 
   @@defaults = {}
   def self.defaults=(x); @@defaults=x; end
@@ -31,7 +35,7 @@ class UrlStore
   end
 
   def decode(string)
-    string = string.to_s.tr(OUT,IN) # convert to base64url <-> RFC4648
+    string = string.to_s.tr(OUT_0_3_5,IN_0_3_5) # convert to base64url <-> RFC4648
     encoder.decode(string)
   end
 


### PR DESCRIPTION
Some applications strictly adhere to RFC4648. Calendars on OSX is one of those applications. While browsers accept the `|` character, Calendars (and others, I'd imagine) don't like it.

This is a backwards compatible change to the encoder, so that all URLs generated going forward do not have the `|` character. URLs that are in the wild with the `|` character will still be decoded properly.
