### PR TITLE
json support

### DIFF
--- a/lib/url_store/compact_encoder.rb
+++ b/lib/url_store/compact_encoder.rb
@@ -30,7 +30,8 @@ class UrlStore
     def serialize(data)
       case @serializer.to_sym
       when :yaml then data.to_yaml
-      when :marshal then Marshal.dump(data)  
+      when :marshal then Marshal.dump(data)
+      when :json then JSON.dump(data)
       end
     end
 
@@ -38,6 +39,7 @@ class UrlStore
       case @serializer.to_sym
       when :yaml then YAML.load(data)
       when :marshal then Marshal.load(data)
+      when :json then JSON.load(data)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
 $LOAD_PATH << 'lib'
 require 'rubygems'
 require 'url_store'
+require 'yaml'
+require 'json'

--- a/spec/url_store/compact_encoder_spec.rb
+++ b/spec/url_store/compact_encoder_spec.rb
@@ -4,6 +4,8 @@ describe UrlStore::CompactEncoder do
   before do
     @encoder = UrlStore::CompactEncoder.new(:secret => 'asdasdsa')
     @data = {:x => 1, 'asdadadadas' => 'asdasdadawvxcxcxcvjs', 'dasdasdadsadad' => 'asdasdwxczvvcjjkdfjkdf'}
+    @json_data = {'x' => 1, 'asdadadadas' => 'asdasdadawvxcxcxcvjs', 'dasdasdadsadad' => 'asdasdwxczvvcjjkdfjkdf'}
+    
   end
 
   it "generates same code for same data" do
@@ -22,6 +24,11 @@ describe UrlStore::CompactEncoder do
   it "can encode/decode with yaml" do
     @encoder = UrlStore::CompactEncoder.new(:secret => 'asdasdsa', :serializer => :yaml)
     @encoder.decode(@encoder.encode(@data)).should == @data
+  end
+
+  it "can encode/decode with json" do
+    @encoder = UrlStore::CompactEncoder.new(:secret => 'asdasdsa', :serializer => :json)
+    @encoder.decode(@encoder.encode(@json_data)).should == @json_data
   end
 
   it "can hash with other hasher" do


### PR DESCRIPTION
Hi,

I'd like to share things between different systems and languages. Although yaml has lot's of implementations it's not accepted everywhere so json would be my next best choice. This patch adds support for it. BTW wouldn't it be better just to pass a "serializer" that responds to dump and load as a config param?

THX
